### PR TITLE
Fix: change order of compute parameters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,6 @@ SET(SOURCE_FILES
   src/iterative_refinement.cpp
   src/jacobi.cpp
   src/generate_svd.cpp
-  src/testing.cpp
 )
 SET(HEADER_FILES
   src/iterative_refinement.h
@@ -31,3 +30,7 @@ install(
   FILES ${HEADER_FILES} 
   DESTINATION include/library_name
 )
+
+add_executable (svd_test src/testing.cpp)
+target_compile_features(svd_test PRIVATE cxx_std_20)
+target_link_libraries(svd_test eigen)

--- a/src/jacobi.cpp
+++ b/src/jacobi.cpp
@@ -39,7 +39,7 @@ int main()
     params_t params;  
     params.epsilon = 1e-18;  
     JTS_SVD<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>> jts_svd;
-    jts_svd.compute(m, params, Eigen::ComputeFullU | Eigen::ComputeFullV);
+    jts_svd.compute(m, Eigen::ComputeFullU | Eigen::ComputeFullV, params);
 
     Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> S(9, 10);
     S.setZero();


### PR DESCRIPTION
Компиляция на clang не работает, но это проблема на стороне GitHub:
https://github.com/actions/runner-images/discussions/9446